### PR TITLE
fix multiselect border

### DIFF
--- a/main.css
+++ b/main.css
@@ -2455,7 +2455,6 @@ div.multiselect {
 	overflow: hidden;
 	margin: auto auto;
 	border: 1px solid #ccc;
-	border-bottom: 0;
 	display: inline-block;
 	padding: 4px 10px 10px 10px;
 	background-color: #f3f3f3;


### PR DESCRIPTION
Missing border on the bottom of the audio multiselect panel:

![image](https://user-images.githubusercontent.com/26873/167494024-4b63f158-5fc9-4f98-a0ac-c7625f8a4e74.png)

after this commit:

![image](https://user-images.githubusercontent.com/26873/167494162-45c3a045-b32f-4be1-8eab-982bfb0b4c71.png)
