### PR TITLE
Feature: Add GitHub Action to diff translation keys against en.json.

### DIFF
--- a/.github/ci-checkTranslations.js
+++ b/.github/ci-checkTranslations.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const path = require("path");
+
+const translationsDir = "translations";
+
+// Load en.json as source of truth
+const en = JSON.parse(fs.readFileSync(path.join(translationsDir, "en.json"), "utf8"));
+
+// Recursively get all keys as "section.key"
+function getAllKeys(obj, prefix = "") {
+  const keys = new Set();
+  for (const [k, v] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === "object" && v !== null) {
+      getAllKeys(v, fullKey).forEach(k => keys.add(k));
+    } else {
+      keys.add(fullKey);
+    }
+  }
+  return keys;
+}
+
+const enKeys = getAllKeys(en);
+const missingReport = {};
+
+// Check every translation file except en.json
+const files = fs.readdirSync(translationsDir).filter(
+  f => f.endsWith(".json") && f !== "en.json" && f !== "blank.json" && f !== "default.json"
+);
+
+for (const filename of files) {
+  const lang = filename.replace(".json", "");
+  const langData = JSON.parse(
+    fs.readFileSync(path.join(translationsDir, filename), "utf8")
+  );
+  const langKeys = getAllKeys(langData);
+
+  const missing = [...enKeys].filter(k => !langKeys.has(k));
+  if (missing.length > 0) {
+    missingReport[lang] = missing.sort();
+  }
+}
+
+// Print report
+if (Object.keys(missingReport).length === 0) {
+  console.log("✅ All translation files are complete!");
+  process.exit(0);
+}
+
+let output = "## ⚠️ Missing Translation Keys\n\n";
+for (const [lang, keys] of Object.entries(missingReport)) {
+  output += `### \`${lang}.json\` — ${keys.length} missing keys\n`;
+  keys.forEach(k => (output += `- \`${k}\`\n`));
+  output += "\n";
+}
+
+console.log(output);
+
+fs.writeFileSync(".github/translation_report.md", output);
+
+process.exit(1); // fail the check so PR shows warning

--- a/.github/ci-generateTranslations.js
+++ b/.github/ci-generateTranslations.js
@@ -89,6 +89,7 @@ const updateList = [
   "en",
   "es",
   "fr",
+  "hi",
   "it",
   "ja",
   "nl",

--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -20,19 +20,14 @@ jobs:
 
       - name: Run translation diff
         id: diff
-        run: node .github/ci-checkTranslations.js
-        continue-on-error: true
-
-      - name: Read report
-        if: failure()
-        id: report
         run: |
+          output=$(node .github/ci-checkTranslations.js || true)
           echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat translation_report.md >> $GITHUB_OUTPUT
+          echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: failure()
+        if: contains(steps.diff.outputs.body, '⚠️')
         uses: actions/github-script@v7
         with:
           script: |
@@ -40,5 +35,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${{ steps.report.outputs.body }}`
+              body: `${{ steps.diff.outputs.body }}`
             })

--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -1,0 +1,44 @@
+name: Translation Diff Check
+
+on:
+  pull_request:
+    paths:
+      - 'translations/**.json'
+
+jobs:
+  check-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '18'
+
+      - name: Run translation diff
+        id: diff
+        run: node .github/ci-checkTranslations.js
+        continue-on-error: true
+
+      - name: Read report
+        if: failure()
+        id: report
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          cat translation_report.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${{ steps.report.outputs.body }}`
+            })

--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -3,7 +3,7 @@ name: Translation Diff Check
 on:
   pull_request:
     paths:
-      - 'translations/**.json'
+      - "translations/**.json"
 
 jobs:
   check-translations:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: "22"
 
       - name: Run translation diff
         id: diff
@@ -29,11 +29,13 @@ jobs:
       - name: Comment on PR
         if: contains(steps.diff.outputs.body, '⚠️')
         uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ steps.diff.outputs.body }}
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${{ steps.diff.outputs.body }}`
+              body: process.env.COMMENT_BODY
             })

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cf/
 wrangler.toml
 package.json
 docs.md
+.github/translation_report.md


### PR DESCRIPTION
### Summary
Adds a GitHub Action that automatically runs whenever a `translations/*.json` file is changed in a PR. It compares every translation file against `en.json` (the source of truth) and posts a comment on the PR listing any missing keys.

### Motivation
This implements the automation that you noted in the translations README:
> *"In the future I will add a Github action so that this automatically occurs with new code posting."*

Currently, when new strings are added to the app, there is no automated way for translation contributors to know which keys are missing in their language files. This Action makes that visible on every PR.

### Files added
- `.github/workflows/translation-check.yml` — workflow definition
- `.github/ci-checkTranslations.js` — script that diffs all translation files against `en.json` and outputs a markdown report

### How it works
1. Triggers on any PR that touches `translations/**.json`
2. Runs `ci-checkTranslations.js` which loads `en.json` as the source of truth
3. Checks every other translation file for missing keys
4. If missing keys are found, posts a comment on the PR listing them by file
5. If all files are complete, no comment is posted

### Example comment output
```
## ⚠️ Missing Translation Keys

### `hi.json` — 1 missing key
- `innerHTML.invite-saved-to-cookie`

### `ja.json` — 2 missing keys
- `innerHTML.restart-whip`
- `miscellaneous.block-from-rejoining`
```

### ⚠️ Required setup for repo maintainer
After merging, please enable write permissions for GitHub Actions so the workflow can post PR comments:

```
Repo → Settings → Actions → General
→ Workflow permissions
→ Select "Read and write permissions"
→ Save
```

### Notes
- Tested on a fork before submitting