### PR TITLE
Support multiple custom TURN servers

### DIFF
--- a/check.html
+++ b/check.html
@@ -1152,9 +1152,9 @@
 				//iframe.allow = "autoplay";
 				var srcString =	"./index.html?push=" + streamID + "&cleanoutput&privacy&"+testType+"&audiodevice=1&fullscreen&transparent&remote&maxbandwidth&speedtest="+zone;
 				
-				if (urlParams.has("turn")) {
-					srcString = srcString + "&turn=" + urlParams.get("turn");
-				}
+				urlParams.getAll("turn").forEach(function (turnvalue) {
+					srcString = srcString + "&turn=" + turnvalue;
+				});
 
 				// we are changing some text on page load, just to demonstrate what's possible.
 				iframe1.onload = function (e) {
@@ -1213,9 +1213,9 @@
 				iframe.allow = "autoplay";
 				var srcString = "./index.html?view=" + streamID + "&cleanoutput&privacy&noaudio&transparent&bitrate=6000&scale=100&speedtest="+zone; // No TURN servers set on the reciever. Don't want to query for TURN servers needlessly.
 
-				if (urlParams.has("turn")) {
-					srcString = srcString + "&turn=" + urlParams.get("turn");
-				}
+				urlParams.getAll("turn").forEach(function (turnvalue) {
+					srcString = srcString + "&turn=" + turnvalue;
+				});
 
 				if (urlParams.has("buffer")) {
 					srcString = srcString + "&buffer=" + urlParams.get("buffer");

--- a/main.js
+++ b/main.js
@@ -6791,7 +6791,8 @@ async function main() {
 	}
 
 	if (urlParams.has("turn")) {
-		var turnstring = urlParams.get("turn");
+		var turnstrings = urlParams.getAll("turn");
+		var turnstring = turnstrings[0];
 
 		if (turnstring == "twilio") {
 			// a sample function on loading remote credentials for TURN servers.
@@ -6848,25 +6849,26 @@ async function main() {
 			};
 		} else {
 			try {
-				//session.configuration = {iceServers: [], sdpSemantics: session.sdpSemantics};
-				turnstring = turnstring.split(";");
-				if (turnstring !== "false") {
-					// false disables the TURN server. Useful for debuggin
-					var turn = {};
-					if (turnstring.length == 3) {
-						turn.username = turnstring[0]; // myusername
-						turn.credential = turnstring[1]; //mypassword
-						turn.urls = [turnstring[2]]; //  ["turn:turn.obs.ninja:443"];
-					} else if (turnstring.length == 1) {
-						turn.urls = [turnstring[0]];
-					}
-					session.configuration = {
-						iceServers: session.stunServers,
-						sdpSemantics: session.sdpSemantics // future-proofing
-					};
+				session.configuration = {
+					iceServers: session.stunServers,
+					sdpSemantics: session.sdpSemantics // future-proofing
+				};
 
-					session.configuration.iceServers.push(turn);
-				}
+				turnstrings.forEach(function (turnvalue) {
+					if (turnvalue == "false") return; // false disables this TURN server. Useful for debugging
+
+					var turnparts = turnvalue.split(";");
+					var turn = {};
+					if (turnparts.length == 3) {
+						turn.username = turnparts[0]; // myusername
+						turn.credential = turnparts[1]; //mypassword
+						turn.urls = [turnparts[2]]; //  ["turn:turn.obs.ninja:443"];
+					} else if (turnparts.length == 1) {
+						turn.urls = [turnparts[0]];
+					}
+
+					if (turn.urls) session.configuration.iceServers.push(turn);
+				});
 			} catch (e) {
 				if (!session.cleanOutput) {
 					warnUser("TURN server parameters were wrong.");

--- a/rawdoc.md
+++ b/rawdoc.md
@@ -12589,11 +12589,17 @@ General Option! ([`&push`](../source-settings/push.md), [`&room`](room.md), [`&v
 
 Example: `&turn=steve;setupYourOwnPlease;turn:turn.vdo.ninja:443`
 
+Multiple TURN servers can be provided by repeating the parameter:
+
+`&turn=user;password;turn:turn1.example.com:3478?transport=udp&turn=user;password;turn:turn2.example.com:443?transport=tcp`
+
 <table><thead><tr><th width="283">Value</th><th>Description</th></tr></thead><tbody><tr><td>(user;pwd;turnserveraddress)</td><td>Set this TURN server to turnserveraddress with username user and password pwd</td></tr><tr><td><code>false</code> | <code>off</code></td><td>Disable the use of the TURN servers</td></tr></tbody></table>
 
 ## Details
 
 Several TURN servers are provided by Steve for free, for now, and these are automatically selected based on your geographic location. You may wish to use your own privately hosted TURN server instead though, and the `&turn` is one flexible way to select it.
+
+When `&turn` is repeated, each custom server is added to the WebRTC ICE server configuration in URL order. This allows applications to provide fallback servers or multiple transports.
 
 ### Locations
 

--- a/speedtest.html
+++ b/speedtest.html
@@ -343,9 +343,9 @@
 				srcString = appendSpeedtestParams(srcString, speedtestPublisherParams);
 				srcString += "&"+testType+"&audiodevice=0&fullscreen&transparent&darkmode&remote&speedtest="+zone;
 				
-				if (urlParams.has("turn")) {
-					srcString = srcString + "&turn=" + urlParams.get("turn");
-				}
+				urlParams.getAll("turn").forEach(function (turnvalue) {
+					srcString = srcString + "&turn=" + turnvalue;
+				});
 
 				// we are changing some text on page load, just to demonstrate what's possible.
 				iframe.onload = function (e) {
@@ -388,9 +388,9 @@
 				var srcString = "./?view=" + streamID + "&cleanish&noaudio&scale=0&speedtest="+zone; // No TURN servers set on the reciever. Don't want to query for TURN servers needlessly.
 				srcString = appendSpeedtestParams(srcString, speedtestViewerParams);
 
-				if (urlParams.has("turn")) {
-					srcString = srcString + "&turn=" + urlParams.get("turn");
-				}
+				urlParams.getAll("turn").forEach(function (turnvalue) {
+					srcString = srcString + "&turn=" + turnvalue;
+				});
 
 				if (urlParams.has("buffer")) {
 					srcString = srcString + "&buffer=" + urlParams.get("buffer");


### PR DESCRIPTION
## Summary

- accept repeated `turn` query parameters and add every valid custom TURN server to `iceServers`
- preserve repeated TURN parameters when `speedtest.html` and `check.html` construct their child iframe URLs
- document repeated parameters for fallback servers and multiple transports

## Motivation

Applications embedding VDO.Ninja may need to provide redundant TURN endpoints or UDP and TCP alternatives. `URLSearchParams.get("turn")` only returned the first parameter, so later fallback entries were silently ignored.

Single `turn` parameters continue to behave as before. Existing first-value modes such as `twilio`, `nostun`, `false`, `off`, and `0` retain their current semantics.

## Validation

- `node --check main.js`
- parsed classic inline scripts in `speedtest.html` and `check.html` with Node's JavaScript parser
- `node .github/ci-validateTranslations.js`
- `node .github/ci-checkTranslationKeys.js`
