### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/thirdparty/jquery/jquery-3.6.0.js
+++ b/thirdparty/jquery/jquery-3.6.0.js
@@ -9207,6 +9207,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
Hi,

Our tool identified a potential vulnerability in a clone function in `thirdparty/jquery/jquery-3.6.0.js` sourced from [jquery/jquery](https://github.com/jquery/jquery). This issue, originally reported in CVE-2015-9251, was resolved in the repository via this commit https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!